### PR TITLE
chore: update dependencies for release 0.9.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Entries are listed in reverse chronological order.
 
+## 0.9.0
+
+* Update `curve25519-dalek` dependency to 4.1.
+* Update `rand` to 0.8.
+* Update `merlin` to 3.0.0.
+* Update crate metadata.
+
 ## 0.8.0
 
 * Update `curve25519-dalek` dependency to 3.0.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ exclude = [
 features = ["nightly"]
 
 [dependencies]
-merlin = "2"
-rand = "0.7"
+merlin = "3.0.0"
+rand = "0.8"
 serde = "1"
 serde_derive = "1"
 thiserror = "1"
 # Disable default features to deselect a backend, then select one below
-curve25519-dalek = { package = "curve25519-dalek-ng", version = "3", default-features = false, features = ["serde", "std"] }
+curve25519-dalek = { package = "curve25519-dalek-ng", version = "4.1", default-features = false, features = ["serde", "std"] }
 
 [dev-dependencies]
 bincode = "1"


### PR DESCRIPTION
Hi @hdevalence , this PR is to use `curve25519-dalek-ng@4.1` as well as newer releases of `rand`, and `merlin`.